### PR TITLE
Various improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,11 @@ edition = "2018"
 
 [dependencies]
 futures = { version = "0.3.21", optional = true }
-tokio = { version = "1.21.1", features = ["full"], optional = true }
 parking_lot = "0.12.1"
+
+[dev-dependencies]
+tokio = { version = "1.21.1", features = ["full"]}
 
 [features]
 default = []
-async_closure = ["dep:tokio", "dep:futures"]
+async_closure = ["dep:futures"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 
 [dependencies]
 futures = { version = "0.3.21", optional = true }
-once_cell = "1.8.0"
 tokio = { version = "1.21.1", features = ["full"], optional = true }
 parking_lot = "0.12.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 futures = { version = "0.3.21", optional = true }
 once_cell = "1.8.0"
 tokio = { version = "1.21.1", features = ["full"], optional = true }
+parking_lot = "0.12.1"
 
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -550,4 +550,16 @@ mod tests {
         };
         crate::async_with_vars([("MY_VAR", Some("ok"))], f);
     }
+
+    #[cfg(feature = "async_closure")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_async_closure_calls_closure() {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let f = async {
+            tx.send(std::env::var("MY_VAR")).unwrap();
+        };
+        crate::async_with_vars([("MY_VAR", Some("ok"))], f);
+        let value = rx.await.unwrap().unwrap();
+        assert_eq!(value, "ok".to_owned());
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,11 +49,10 @@ use std::ffi::OsStr;
 use std::hash::Hash;
 use std::panic::{self, RefUnwindSafe, UnwindSafe};
 
-use once_cell::sync::Lazy;
 use parking_lot::ReentrantMutex;
 
 /// Make sure that the environment isn't modified concurrently.
-static SERIAL_TEST: Lazy<ReentrantMutex<()>> = Lazy::new(Default::default);
+static SERIAL_TEST: ReentrantMutex<()> = ReentrantMutex::new(());
 
 /// Sets a single environment variable for the duration of the closure.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,6 @@ use std::collections::HashMap;
 use std::env;
 use std::ffi::{OsStr, OsString};
 use std::hash::Hash;
-use std::panic::{RefUnwindSafe, UnwindSafe};
 
 use parking_lot::{ReentrantMutex, ReentrantMutexGuard};
 
@@ -64,7 +63,7 @@ pub fn with_var<K, V, F, R>(key: K, value: Option<V>, closure: F) -> R
 where
     K: AsRef<OsStr> + Clone + Eq + Hash,
     V: AsRef<OsStr> + Clone,
-    F: Fn() -> R + UnwindSafe + RefUnwindSafe,
+    F: Fn() -> R,
 {
     with_vars([(key, value)], closure)
 }
@@ -83,7 +82,7 @@ where
 pub fn with_var_unset<K, F, R>(key: K, closure: F) -> R
 where
     K: AsRef<OsStr> + Clone + Eq + Hash,
-    F: Fn() -> R + UnwindSafe + RefUnwindSafe,
+    F: Fn() -> R,
 {
     with_var(key, None::<&str>, closure)
 }
@@ -128,7 +127,7 @@ pub fn with_vars<K, V, F, R>(kvs: impl AsRef<[(K, Option<V>)]>, closure: F) -> R
 where
     K: AsRef<OsStr> + Clone + Eq + Hash,
     V: AsRef<OsStr> + Clone,
-    F: Fn() -> R + UnwindSafe + RefUnwindSafe,
+    F: Fn() -> R,
 {
     let old_env = RestoreEnv::capture(
         SERIAL_TEST.lock(),
@@ -163,7 +162,7 @@ where
 pub fn with_vars_unset<K, F, R>(keys: impl AsRef<[K]>, closure: F) -> R
 where
     K: AsRef<OsStr> + Clone + Eq + Hash,
-    F: Fn() -> R + UnwindSafe + RefUnwindSafe,
+    F: Fn() -> R,
 {
     let kvs = keys
         .as_ref()
@@ -202,7 +201,7 @@ pub fn async_with_vars<K, V, F>(kvs: impl AsRef<[(K, Option<V>)]>, closure: F)
 where
     K: AsRef<OsStr> + Clone + Eq + Hash,
     V: AsRef<OsStr> + Clone,
-    F: std::future::Future<Output = ()> + std::panic::UnwindSafe + std::future::IntoFuture,
+    F: std::future::Future<Output = ()> + std::future::IntoFuture,
 {
     let old_env = RestoreEnv::capture(
         SERIAL_TEST.lock(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,7 @@ where
 ///     crate::async_with_vars([("MY_VAR", Some("ok"))], check_var());
 /// }
 /// ```
-pub fn async_with_vars<K, V, F>(kvs: impl AsRef<[(K, Option<V>)]>, closure: F)
+pub async fn async_with_vars<K, V, F>(kvs: impl AsRef<[(K, Option<V>)]>, closure: F)
 where
     K: AsRef<OsStr> + Clone + Eq + Hash,
     V: AsRef<OsStr> + Clone,
@@ -210,7 +210,7 @@ where
     for (key, value) in kvs.as_ref() {
         update_env(key, value.as_ref());
     }
-    closure;
+    closure.await;
     drop(old_env)
 }
 
@@ -543,12 +543,12 @@ mod tests {
     #[cfg(feature = "async_closure")]
     #[tokio::test]
     async fn test_async_closure() {
-        crate::async_with_vars([("MY_VAR", Some("ok"))], check_var());
+        crate::async_with_vars([("MY_VAR", Some("ok"))], check_var()).await;
         let f = async {
             let v = std::env::var("MY_VAR").unwrap();
             assert_eq!(v, "ok".to_owned());
         };
-        crate::async_with_vars([("MY_VAR", Some("ok"))], f);
+        crate::async_with_vars([("MY_VAR", Some("ok"))], f).await;
     }
 
     #[cfg(feature = "async_closure")]
@@ -558,7 +558,7 @@ mod tests {
         let f = async {
             tx.send(std::env::var("MY_VAR")).unwrap();
         };
-        crate::async_with_vars([("MY_VAR", Some("ok"))], f);
+        crate::async_with_vars([("MY_VAR", Some("ok"))], f).await;
         let value = rx.await.unwrap().unwrap();
         assert_eq!(value, "ok".to_owned());
     }


### PR DESCRIPTION
Hello,

I'd like to submit a few improvements to this crate in this merge request.  It

- enables nested with_var without deadlocks (by means of parking_lot's reentrant mutex),
- removes the once_cell dependency (ReentrantMutex::new is const, so we can assign directly to a `static` value),
- removes the unused runtime dependency on tokio (and adds a dev dependency on tokio instead),
- rewrites the restore implementation on top of drop, instead of manual unwinding,
- removes the unwind and panic safety bounds which are no longer required,
- and fixes async_with_vars to actually use the passed future (it never did, but I presume that was the intention).

See commits for all details.  
