### PR TITLE
chore: Use once_cell for lazy initialization of mutex in lib.rs file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 futures = { version = "0.3.21", optional = true }
+once_cell = "1.17.1"
 parking_lot = "0.12.1"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@
 //! ```
 //!
 
+use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::env;
 use std::ffi::{OsStr, OsString};
@@ -51,7 +52,7 @@ use std::hash::Hash;
 use parking_lot::{ReentrantMutex, ReentrantMutexGuard};
 
 /// Make sure that the environment isn't modified concurrently.
-static SERIAL_TEST: ReentrantMutex<()> = ReentrantMutex::new(());
+static SERIAL_TEST: Lazy<ReentrantMutex<()>> = Lazy::new(|| ReentrantMutex::new(()));
 
 /// Sets a single environment variable for the duration of the closure.
 ///


### PR DESCRIPTION
- Use `once_cell` for lazy initialization of `SERIAL_TEST` mutex in `lib.rs`

This prevents the following error under some Rust versions:
```
error[E0015]: cannot call non-const fn `ReentrantMutex::<parking_lot::RawMutex, RawThreadId, ()>::new` in statics
  --> /Users/huitseeker/.cargo/registry/src/github.com-1ecc6299db9ec823/temp-env-0.3.3/src/lib.rs:54:42
   |
54 | static SERIAL_TEST: ReentrantMutex<()> = ReentrantMutex::new(());
   |                                          ^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: calls in statics are limited to constant functions, tuple structs and tuple variants
   = note: consider wrapping this expression in `Lazy::new(|| ...)` from the `once_cell` crate: https://crates.io/crates/once_cell

For more information about this error, try `rustc --explain E0015`.
```