### PR TITLE
chore: run CI also on MSRV

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,38 @@ name: build
 
 on: [push, pull_request]
 
+env:
+  MSRV: 1.62.1
+
 jobs:
+  msrv:
+    name: MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v2
+
+      - name: Cache Dependencies & Build Outputs
+        uses: actions/cache@v2
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.MSRV }}
+          override: true
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          # Test with default features only, as the async support needs a newer
+          # Rust version.
+          args: --workspace
+
   build:
     name: Build
     strategy:


### PR DESCRIPTION
Run the project on CI also on the minimum supported Rust version to make sure we don't break it accidentally.