### PR TITLE
Returning result from async closure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -563,4 +563,30 @@ mod tests {
         let value = rx.await.unwrap().unwrap();
         assert_eq!(value, "ok".to_owned());
     }
+
+    #[cfg(feature = "async_closure")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_async_closure_returns_value() {
+        let one_not_set = env::var("ONE");
+        assert!(one_not_set.is_err(), "`ONE` must not be set.");
+        let two_not_set = env::var("TWO");
+        assert!(two_not_set.is_err(), "`TWO` must not be set.");
+
+        let r = crate::async_with_vars([("ONE", Some("1")), ("TWO", Some("2"))], async {
+            let one_is_set = env::var("ONE").unwrap();
+            let two_is_set = env::var("TWO").unwrap();
+            (one_is_set, two_is_set)
+        })
+        .await;
+
+        let (one_from_closure, two_from_closure) = r;
+
+        assert_eq!(one_from_closure, "1", "`ONE` had to be set to \"1\".");
+        assert_eq!(two_from_closure, "2", "`TWO` had to be set to \"2\".");
+
+        let one_not_set_after = env::var("ONE");
+        assert!(one_not_set_after.is_err(), "`ONE` must not be set.");
+        let two_not_set_after = env::var("TWO");
+        assert!(two_not_set_after.is_err(), "`TWO` must not be set.");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -566,7 +566,7 @@ mod tests {
 
     #[cfg(feature = "async_closure")]
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_async_closure_returns_value() {
+    async fn test_async_with_vars_set_returning() {
         let one_not_set = env::var("ONE");
         assert!(one_not_set.is_err(), "`ONE` must not be set.");
         let two_not_set = env::var("TWO");


### PR DESCRIPTION
Mirrors the behavior of `with_vars` for `async_with_vars` and allows to return values.