### PR TITLE
chore: check MSRV for building not for testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Test
         uses: actions-rs/cargo@v1
         with:
-          command: test
+          command: build
           # Test with default features only, as the async support needs a newer
           # Rust version.
           args: --workspace


### PR DESCRIPTION
tokio v1.32.0 needs Rust 1.63 or newer, while our MSRV is 1.62.1. It is only a dev depdendency. Prior to this commit, we ran the tests, with this commit we only build the with the MSRV, that should be good enough.