### PR TITLE
chore: release 0.3.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temp-env"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Volker Mische <volker.mische@gmail.com>", "Fabian Braun <fabian-braun-os@mailbox.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/vmx/temp-env"


### PR DESCRIPTION
The minimum supported Rust version is increased to 1.63.0. Though it's a patch release as the previous version won't work with 1.62.1 due to `libc` now requiring 1.63.0.

The only change since the last release are improvements to the tests.

---

Once this PR is merged, I'll do the release. I'll leave this PR open for a bit, in case there are other things people would like to so or in case anyone has objections to doing this release as a new patch version.